### PR TITLE
Adding aliases for migrate command

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,5 +1,4 @@
 alias migrate="rake db:migrate db:rollback && rake db:migrate"
-alias m="migrate"
 
 # Include custom aliases
 [[ -f ~/.aliases.local ]] && source ~/.aliases.local


### PR DESCRIPTION
- Adding an alias to `rake db:migrate db:rollback && rake db:migrate`

http://robots.thoughtbot.com/workflows-for-writing-migrations-with-rollbacks-in-mind

`rake db:migrate db:rollback` will run any pending migrations and then
attempt to roll back those migrations. If the migration and rollback are
successful (signified by `&&`), `rake db:migrate` will then run the
migration again. If the command is not successful, an error will be
thrown. In this way we can be confident our migrations' down commands
are syntactically valid (no typos) and logically valid (no invalid
castings of values, for example).
