### PR TITLE
Add common items to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -34,7 +34,7 @@ install zsh-completions
 install wget 
 
 # Install more recent versions of some OS X tools
-install mvim --override-system-vim
+install macvim --override-system-vim
 
 # Install other useful binaries
 install ack


### PR DESCRIPTION
Never thought of this till now. This way someone can run `brew bundle Brewfile` to install/upgrade any OSX packages. It is not part of the default `rcup` run so you can still use this on any *nix system.
