### PR TITLE
Feature/directorize hooks

### DIFF
--- a/hooks/post-up/antigen
+++ b/hooks/post-up/antigen
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ ! -e $HOME/.zsh/antigen ]; then
+  git clone https://github.com/zsh-users/antigen.git $HOME/.zsh/antigen
+fi

--- a/hooks/post-up/vim
+++ b/hooks/post-up/vim
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ ! -e $HOME/.vim/bundle/vundle ]; then
+  git clone https://github.com/gmarik/vundle.git $HOME/.vim/bundle/vundle
+fi
+vim -u $HOME/.vimrc.bundles +BundleInstall +qa


### PR DESCRIPTION
rcm supports directories for hooks. Change things to use those instead for orginization and also to allow forks to add their own hooks without interfering with master.
